### PR TITLE
Fix try_rebase on Windows

### DIFF
--- a/src/ghp_import/__main__.py
+++ b/src/ghp_import/__main__.py
@@ -74,7 +74,7 @@ def try_rebase(remote, branch):
     (rev, ignore) = p.communicate()
     if p.wait() != 0:
         return True
-    cmd = ['git', 'update-ref', 'refs/heads/%s' % branch, rev.strip()]
+    cmd = ['git', 'update-ref', 'refs/heads/%s' % branch, rev.decode('utf-8').strip()]
     if sp.call(cmd) != 0:
         return False
     return True


### PR DESCRIPTION
subprocess on Windows requires Unicode strings to be passed as part of argument lists.
